### PR TITLE
Fix bug in notebook 1

### DIFF
--- a/Analytics_Deployment/synapse-workspace/notebooks/1 - Clean Data.ipynb
+++ b/Analytics_Deployment/synapse-workspace/notebooks/1 - Clean Data.ipynb
@@ -190,7 +190,7 @@
       "source": [
         "# split category code into category and subcategory\n",
         "df = df.withColumn('category', split(col('category_code'), '\\.').getItem(0))\\\n",
-        "       .withColumn('subcategory', split(col('category_code'), '\\.').getItem(1))\"
+        "       .withColumn('subcategory', split(col('category_code'), '\\.').getItem(1))"
       ],
       "attachments": {}
     },

--- a/Analytics_Deployment/synapse-workspace/notebooks/1 - Clean Data.ipynb
+++ b/Analytics_Deployment/synapse-workspace/notebooks/1 - Clean Data.ipynb
@@ -190,7 +190,7 @@
       "source": [
         "# split category code into category and subcategory\n",
         "df = df.withColumn('category', split(col('category_code'), '\\.').getItem(0))\\\n",
-        "       .withColumn('subcategory', split(col('category_code'), '\\.').getItem(1))\\"
+        "       .withColumn('subcategory', split(col('category_code'), '\\.').getItem(1))\"
       ],
       "attachments": {}
     },


### PR DESCRIPTION
there was an extra backslash in Notebook 1. at the end here:


# split category code into category and subcategory
df = df.withColumn('category', split(col('category_code'), '\.').getItem(0))\
       .withColumn('subcategory', split(col('category_code'), '\.').getItem(1))\

I removed that.